### PR TITLE
Fix link to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Licensed under the Apache License, Version 2.0 (the License);
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.orglicensesLICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an AS IS BASIS,


### PR DESCRIPTION
License link where missing two `/`
